### PR TITLE
Add release workflow for tagged CLI builds

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,56 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag points to main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor $(git rev-parse origin/main) "$GITHUB_SHA"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build release binaries
+        run: |
+          mkdir -p dist
+          for os in linux darwin windows; do
+            for arch in amd64 arm64; do
+              suffix=""
+              [ "$os" = "windows" ] && suffix=".exe"
+              GOOS=$os GOARCH=$arch go build -ldflags "-X main.version=${GITHUB_REF_NAME}" -o "dist/names-${os}-${arch}${suffix}" ./cmd/names
+            done
+          done
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: names-${{ github.ref_name }}
+          path: dist/*
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/names/main.go
+++ b/cmd/names/main.go
@@ -8,7 +8,10 @@ import (
 	"github.com/curtiscovington/ssa-names/internal/cli"
 )
 
+var version = "dev"
+
 func main() {
+	cli.Version = version
 	app := cli.NewApp(dataset.Files, os.Stdout, os.Stderr)
 	if err := app.Run(os.Args[1:]); err != nil {
 		log.Fatal(err)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -15,6 +15,9 @@ import (
 	"github.com/curtiscovington/ssa-names/internal/visualize"
 )
 
+// Version is the semantic version of the CLI binary and is overridden at build time.
+var Version = "dev"
+
 // App wraps the command-line interface logic so it can be reused in tests.
 type App struct {
 	Dataset fs.FS
@@ -29,6 +32,14 @@ func NewApp(dataset fs.FS, stdout, stderr io.Writer) *App {
 
 // Run dispatches to the appropriate sub-command based on the provided args.
 func (a *App) Run(args []string) error {
+	if len(args) > 0 {
+		switch args[0] {
+		case "version", "--version", "-v":
+			a.printVersion()
+			return nil
+		}
+	}
+
 	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
 		return a.runTop(args)
 	}
@@ -46,6 +57,14 @@ func (a *App) Run(args []string) error {
 		a.printUsage()
 		return fmt.Errorf("unknown command: %s", args[0])
 	}
+}
+
+func (a *App) printVersion() {
+	version := strings.TrimSpace(Version)
+	if version == "" {
+		version = "dev"
+	}
+	fmt.Fprintf(a.Stdout, "names %s\n", version)
 }
 
 func (a *App) runTop(args []string) error {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -227,3 +227,26 @@ func TestAppGenerateMultiple(t *testing.T) {
 		t.Fatalf("expected no stderr output, got %q", stderr.String())
 	}
 }
+
+func TestAppVersionCommand(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	oldVersion := cli.Version
+	t.Cleanup(func() {
+		cli.Version = oldVersion
+	})
+	cli.Version = "v1.2.3"
+	app := cli.NewApp(sampleFS(), stdout, stderr)
+
+	if err := app.Run([]string{"--version"}); err != nil {
+		t.Fatalf("Run version: %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "names v1.2.3" {
+		t.Fatalf("unexpected version output: %q", got)
+	}
+
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr output, got %q", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on version tags
- ensure the tagged commit matches main, run go test, and build multi-platform binaries with embedded version metadata
- upload artifacts and publish a release with the compiled binaries
- expose a --version flag in the CLI wired to the embedded release metadata

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68daec825eec83268635a1668186bd58